### PR TITLE
Add architecture specific cache line size

### DIFF
--- a/include/onnxruntime/core/common/common.h
+++ b/include/onnxruntime/core/common/common.h
@@ -66,6 +66,21 @@ using TimePoint = std::chrono::high_resolution_clock::time_point;
 #define ORT_ATTRIBUTE_UNUSED
 #endif
 
+// ORT_CACHELINE_SIZE
+//
+// Defines L1 cache line size for various architectures
+// Can be used for the purpose of aligning data on cache line boundaries
+#if defined(__x86_64__)
+#define ORT_CACHELINE_SIZE 64
+#elif defined(__aarch64__)
+#define ORT_CACHELINE_SIZE 64
+#elif defined(__powerpc64__)
+#define ORT_CACHELINE_SIZE 128
+#else
+// Default for all other architectures
+#define ORT_CACHELINE_SIZE 64
+#endif
+
 #ifdef ORT_NO_EXCEPTIONS
 // Print the given final message, the message must be a null terminated char*
 // ORT will abort after printing the message.

--- a/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
+++ b/include/onnxruntime/core/platform/EigenNonBlockingThreadPool.h
@@ -47,6 +47,7 @@
 #elif defined(_MSC_VER)
 #pragma warning(pop)
 #endif
+#include "core/common/common.h"
 #include "core/common/denormal.h"
 #include "core/common/inlined_containers_fwd.h"
 #include "core/common/spin_pause.h"
@@ -190,9 +191,9 @@ enum class PushResult {
 //   support for aligned allocation which we could use here.
 
 #if defined(__x86_64__)
-#define ORT_FALSE_SHARING_BYTES 128
+#define ORT_FALSE_SHARING_BYTES (ORT_CACHELINE_SIZE * 2)
 #else
-#define ORT_FALSE_SHARING_BYTES 64
+#define ORT_FALSE_SHARING_BYTES ORT_CACHELINE_SIZE
 #endif
 
 #define ORT_ALIGN_TO_AVOID_FALSE_SHARING alignas(ORT_FALSE_SHARING_BYTES)


### PR DESCRIPTION
Introduce ORT_CACHELINE_SIZE which can be used for the purpose of aligning data on cache line boundaries.

### Description
<!-- Describe your changes. -->



### Motivation and Context
<!-- - Why is this change required? What problem does it solve?
- If it fixes an open issue, please link to the issue here. -->


